### PR TITLE
fix(GameSection,SpotifySection): add self-start to images

### DIFF
--- a/src/components/GameSection.tsx
+++ b/src/components/GameSection.tsx
@@ -73,7 +73,7 @@ const GameSection = ({
       </div>
       <div className="flex items-center gap-3">
         {largeImage ? (
-          <div className="flex gap-1 min-w-[65px]">
+          <div className="flex gap-1 min-w-[65px] self-start">
             <div className="relative justify-center items-center">
               <img
                 src={largeImage}
@@ -92,7 +92,7 @@ const GameSection = ({
         ) : (
           <>
             {smallImage && (
-              <div className="min-w-[65px]">
+              <div className="min-w-[65px] self-start">
                 <img
                   src={smallImage}
                   alt=""

--- a/src/components/SpotifySection.tsx
+++ b/src/components/SpotifySection.tsx
@@ -63,7 +63,7 @@ const SpotifySection = ({
       </div>
       <div className="flex items-center gap-3">
         {artUrl && (
-          <div className="min-w-[65px]">
+          <div className="min-w-[65px] self-start">
             {trackUrl ? (
               <a href={trackUrl} target="_blank">
                 <img


### PR DESCRIPTION
Added `align-self: flex-start` to make images align to the start of the div, so it looks more closely to how Discord renders them.