### PR TITLE
feat(SpotifySection): add seek bar

### DIFF
--- a/src/components/GameSection.tsx
+++ b/src/components/GameSection.tsx
@@ -1,3 +1,4 @@
+import { formatTime } from "../helpers/helperFunctions";
 import { Party } from "../interfaces/Party";
 import BaseSection from "./BaseSection";
 import SectionTitle from "./SectionTitle";
@@ -42,28 +43,16 @@ const GameSection = ({
   startTime?: number;
   buttonText?: string;
 }) => {
-  // Adapted from: https://github.com/kyranet/kyra.dev/blob/main/components/user/card-activity.vue
-  const secondAsMilliseconds = 1000
-  const minuteAsMilliseconds = secondAsMilliseconds * 60
-  const hourAsMilliseconds = minuteAsMilliseconds * 60
-
   const [currentDateTime, setCurrentDateTime] = useState(new Date());
 
   // Update to current time every second
   useEffect(() => {
-    const interval = setInterval(() => setCurrentDateTime(new Date()), secondAsMilliseconds)
+    const interval = setInterval(() => setCurrentDateTime(new Date()), 1000)
     return () => clearInterval(interval)
   }, [startTime])
 
-  const formatTime = () => {
-    const distance = currentDateTime.getTime() - startTime!
-    const seconds = Math.floor((distance / secondAsMilliseconds) % 60).toString().padStart(2, '0')
-    const minutes = Math.floor((distance / minuteAsMilliseconds) % 60).toString().padStart(2, '0')
-    if (distance < hourAsMilliseconds) return `${minutes}:${seconds}`
+  const elapsedTime = formatTime(startTime!, currentDateTime.getTime());
 
-    const hours = Math.floor((distance / hourAsMilliseconds)).toString().padStart(2, '0')
-    return `${hours}:${minutes}:${seconds}`
-  }
   return (
     <BaseSection>
       <div className="flex justify-between">
@@ -134,7 +123,7 @@ const GameSection = ({
             </>
           )}
           {startTime && (
-            <p>{timeAlignment === 'left' ? `${formatTime()} ${elapsedText}` : `${elapsedText} ${formatTime()}`}</p>
+            <p>{timeAlignment === 'left' ? `${elapsedTime} ${elapsedText}` : `${elapsedText} ${elapsedTime}`}</p>
           )}
         </div>
       </div>

--- a/src/components/LanyardDiscordCard.tsx
+++ b/src/components/LanyardDiscordCard.tsx
@@ -90,6 +90,8 @@ const LanyardDiscordCard = ({
           album={lanyardData.spotify.album}
           artUrl={lanyardData.spotify.album_art_url}
           trackUrl={`https://open.spotify.com/track/${lanyardData.spotify.track_id}`}
+          startTimeMs={lanyardData.spotify.timestamps.start}
+          endTimeMs={lanyardData.spotify.timestamps.end}
         />
       );
     }

--- a/src/components/SeekBar.tsx
+++ b/src/components/SeekBar.tsx
@@ -1,0 +1,39 @@
+/**
+ * Renders the seek bar for the SpotifySection component.
+ */
+import { useEffect, useState } from "react";
+import { formatTime } from "../helpers/helperFunctions";
+
+const SeekBar = ({
+  startTimeMs,
+  endTimeMs,
+}: {
+  startTimeMs: number;
+  endTimeMs: number;
+}) => {
+
+  const [currentDateTime, setCurrentDateTime] = useState(new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => setCurrentDateTime(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, [startTimeMs]);
+
+  const currentPosition = formatTime(startTimeMs, currentDateTime.getTime());
+  const songDuration = formatTime(startTimeMs, endTimeMs);
+  const percentage = ((currentDateTime.getTime() - startTimeMs) / (endTimeMs - startTimeMs)) * 100;
+
+  return (
+    <div className="text-[0.75rem] flex flex-col gap-0 mt-3">
+        <div className="bar h-1 bg-neutral-700 rounded-xl">
+            <div className="progress h-1 bg-primary rounded-xl bg-white" style={{ width: `${percentage}%` }}></div>
+        </div>
+        <div className="flex justify-between items-start">
+            <p className="my-0 py-0">{currentPosition}</p>
+            <p className="my-0 py-0">{songDuration}</p>
+        </div>
+    </div>
+  );
+};
+
+export default SeekBar;

--- a/src/components/SpotifySection.tsx
+++ b/src/components/SpotifySection.tsx
@@ -1,5 +1,6 @@
 import BaseSection from "./BaseSection";
 import SectionTitle from "./SectionTitle";
+import SeekBar from "./SeekBar";
 /**
  * Renders a section displaying Spotify song information.
  *
@@ -9,6 +10,8 @@ import SectionTitle from "./SectionTitle";
  * @param {string} album - The name of the album
  * @param {string} artUrl - The URL of the album art
  * @param {string} trackUrl - The URL of the track on Spotify
+ * @param {number} startTimeMs - The start time of the song in milliseconds
+ * @param {number} endTimeMs - The end time of the song in milliseconds
  * @return {JSX.Element} The rendered Spotify section
  */
 const SpotifySection = ({
@@ -18,6 +21,8 @@ const SpotifySection = ({
   album,
   artUrl,
   trackUrl,
+  startTimeMs,
+  endTimeMs,
 }: {
   title?: string;
   song: string;
@@ -25,6 +30,8 @@ const SpotifySection = ({
   album: string;
   artUrl?: string;
   trackUrl?: string;
+  startTimeMs?: number;
+  endTimeMs?: number;
 }) => {
   return (
     <BaseSection>
@@ -93,6 +100,11 @@ const SpotifySection = ({
           </p>
         </div>
       </div>
+      
+      { startTimeMs && endTimeMs && (
+        <SeekBar startTimeMs={startTimeMs} endTimeMs={endTimeMs} />
+      )}
+
       {trackUrl && (
         <a
           target="_blank"

--- a/src/helpers/helperFunctions.ts
+++ b/src/helpers/helperFunctions.ts
@@ -1,0 +1,15 @@
+// Formats the time in milliseconds to a string in the format of "hh:mm:ss" or "mm:ss" if the time is less than an hour.
+export const formatTime = (startTimeMs: number, endTimeMs: number) => {
+  const secondAsMilliseconds = 1000;
+  const minuteAsMilliseconds = secondAsMilliseconds * 60;
+  const hourAsMilliseconds = minuteAsMilliseconds * 60;
+
+  const distance = endTimeMs - startTimeMs;
+  const seconds = Math.floor((distance / secondAsMilliseconds) % 60).toString().padStart(2, "0");
+  const minutes = Math.floor((distance / minuteAsMilliseconds) % 60).toString().padStart(2, "0");
+  if (distance < hourAsMilliseconds) return `${minutes}:${seconds}`;
+
+  const hours = Math.floor(distance / hourAsMilliseconds).toString().padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}
+

--- a/src/interfaces/SpotifySectionProps.ts
+++ b/src/interfaces/SpotifySectionProps.ts
@@ -5,4 +5,6 @@ export interface SpotifySectionProps {
   album: string;
   artUrl?: string;
   trackUrl?: string;
+  startTimeMs?: number;
+  endTimeMs?: number;
 }


### PR DESCRIPTION
Added a seek bar to SpotifySection.

Also refactored GameSection to extract formatTime to a separate file.

![image](https://github.com/MiguelHigueraDev/discord-card-react/assets/133175356/70ec1af9-abba-4a5c-913b-f4f4f2b4c1b2)
