### PR TITLE
feat: add support for multiple activities at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ A React Component that renders a Discord profile card. Can sync with your Discor
 </p>
 
 ## Table of Contents:
+
 1. [Features](#features)
 2. [How to use](#how-to-use)
 3. [State and input handler example](#state-and-input-handler-example)
 4. [Translations (i18n)](#translations-i18n)
 5. [How to contribute](#how-to-contribute)
 6. [Credits](#credits)
-
 
 ## Features:
 
@@ -73,8 +73,7 @@ Pass props to it to customize. Like the name says, it's static and doesn't updat
     username: "username",
     // Pronouns are optional
     pronouns: "he/him",
-    }}
-
+  }}
   // All these are optional
   badges={[{ name: "Active Developer", iconUrl: "developer-badge.png" }]}
   status={{
@@ -106,7 +105,8 @@ Pass props to it to customize. Like the name says, it's static and doesn't updat
     title: "You can add alternative titles to all sections that have titles",
     serverJoinDate: "1 Sep 2020",
     serverIconUrl: "https://asdasd.com/icon.png",
-    serverName: "This is used as the alt attribute for the image, for accessibility"
+    serverName:
+      "This is used as the alt attribute for the image, for accessibility",
   }}
   roles={{
     roles: [
@@ -183,7 +183,6 @@ Make sure to set up Lanyard by following [the instructions](https://github.com/P
     // Pronouns are optional
     pronouns: "he/him",
   }}
-
   // All these are optional
   badges={[{ name: "Active Developer", iconUrl: "developer-badge.png" }]}
   status={{
@@ -212,7 +211,8 @@ Make sure to set up Lanyard by following [the instructions](https://github.com/P
     title: "You can add alternative titles to all sections that have titles",
     serverJoinDate: "1 Sep 2020",
     serverIconUrl: "https://asdasd.com/icon.png",
-    serverName: "This is used as the alt attribute for the image, for accessibility"
+    serverName:
+      "This is used as the alt attribute for the image, for accessibility",
   }}
   roles={{
     roles: [
@@ -240,6 +240,8 @@ Make sure to set up Lanyard by following [the instructions](https://github.com/P
   // If set to "activity", the behavior is the same as default
   // If set to "spotify", the Spotify card will be given priority over the Game card
   priority="none"
+  // Maximum number of activities displayed at the same time (default: 1)
+  maxActivities="1"
   spotify={{
     show: true,
     title: "Listening to Spotify",
@@ -274,19 +276,19 @@ function handleMessageChange(event) {
 }
 
 <DiscordCard
-// Your card here...
-note={{
-  // The state and input handler
-  note: note,
-  handleInput: handleNoteChange,
-}}
-message={{
-  // The state and input handler
-  message: message,
-  handleInput: handleMessageChange,
-}}
-// Rest of the card...
-/>
+  // Your card here...
+  note={{
+    // The state and input handler
+    note: note,
+    handleInput: handleNoteChange,
+  }}
+  message={{
+    // The state and input handler
+    message: message,
+    handleInput: handleMessageChange,
+  }}
+  // Rest of the card...
+/>;
 ```
 
 ## Translations (i18n)
@@ -306,9 +308,11 @@ memberSince={{
   serverName: "Servidor X"
 }}
 ```
+
 ![i18n example](/github/member-since-i18n.png)
 
 ## How to contribute
+
 All contributions are greatly appreciated! Please keep PRs short, focusing only in one feature/fix you want to implement, so they can be easily reviewed.
 
 Follow these instructions if you are a newcomer:
@@ -317,7 +321,7 @@ Follow these instructions if you are a newcomer:
 2. Make a new branch using the command `git switch -c BranchName`
 3. Install dependencies using your package manager of choice (for example: `npm install`)
 4. Start the development server to see your changes live using `npm run dev`
-6. Once you have finished your work, commit your changes and [open a PR!](https://github.com/MiguelHigueraDev/discord-card-react/pulls)
+5. Once you have finished your work, commit your changes and [open a PR!](https://github.com/MiguelHigueraDev/discord-card-react/pulls)
 
 ## Credits
 

--- a/src/components/LanyardDiscordCard.tsx
+++ b/src/components/LanyardDiscordCard.tsx
@@ -1,5 +1,5 @@
 import BaseDiscordCard from "./BaseDiscordCard";
-import { useLanyard } from "react-use-lanyard";
+import { Activity, useLanyard } from "react-use-lanyard";
 import { Badge } from "../interfaces/Badge";
 import { BasicInfoSectionProps } from "../interfaces/BasicInfoSectionProps";
 import { AboutMeSectionProps } from "../interfaces/AboutMeSectionProps";
@@ -21,6 +21,7 @@ import ActivitySection from "./ActivitySection";
 import { ActivityPriority } from "../interfaces/ActivityPriority";
 import { LanyardActivitySectionProps } from "../interfaces/lanyard/LanyardActivitySectionProps";
 import { LanyardSpotifySectionProps } from "../interfaces/lanyard/LanyardSpotifySectionProps";
+import { ReactNode } from "react";
 
 const LanyardDiscordCard = ({
   userId,
@@ -52,6 +53,7 @@ const LanyardDiscordCard = ({
   note,
   message,
   priority = "default",
+  maxActivities = 2,
   children,
 }: {
   userId: string;
@@ -71,6 +73,7 @@ const LanyardDiscordCard = ({
   note?: NoteSectionProps;
   message?: MessageSectionProps;
   priority?: ActivityPriority;
+  maxActivities?: number;
   children?: React.JSX.Element | React.JSX.Element[];
 }) => {
   const { status: lanyardData } = useLanyard({
@@ -79,26 +82,16 @@ const LanyardDiscordCard = ({
     apiUrl,
   });
 
-  const currentActivity =
+  const activities =
     lanyardData && lanyardData.activities
-      ? lanyardData.activities.find((ac) => ac.type === 0)
+      ? lanyardData.activities
+          .filter((ac) => ac.type === 0)
+          .slice(0, maxActivities)
       : null;
 
-  // This handles external assets in case they are present
-  const largeImageId = currentActivity?.assets?.large_image;
-  const smallImageId = currentActivity?.assets?.small_image;
-  let largeImageExternalUrl = null;
-  let smallImageExternalUrl = null;
-
-  if (largeImageId?.startsWith("mp:external")) {
-    const largeImageUrlParts = largeImageId.split("/");
-    largeImageExternalUrl = largeImageUrlParts.slice(3).join("/");
-  }
-
-  if (smallImageId?.startsWith("mp:external")) {
-    const smallImageUrlParts = smallImageId.split("/");
-    smallImageExternalUrl = smallImageUrlParts.slice(3).join("/");
-  }
+  /*
+   * This handles external assets in case they are present
+   */
 
   const renderSpotifySection = () => {
     if (spotify.show && lanyardData && lanyardData.spotify) {
@@ -120,57 +113,91 @@ const LanyardDiscordCard = ({
       );
     }
   };
-  const renderActivitySection = () => {
-    if (activity.show && currentActivity) {
+
+  const getImageUrls = (activity: Activity) => {
+    const largeImageId = activity.assets?.large_image;
+    const smallImageId = activity.assets?.small_image;
+    let largeImageExternalUrl = null;
+    let smallImageExternalUrl = null;
+
+    if (largeImageId?.startsWith("mp:external")) {
+      const largeImageUrlParts = largeImageId.split("/");
+      largeImageExternalUrl = largeImageUrlParts.slice(3).join("/");
+    }
+
+    if (smallImageId?.startsWith("mp:external")) {
+      const smallImageUrlParts = smallImageId.split("/");
+      smallImageExternalUrl = smallImageUrlParts.slice(3).join("/");
+    }
+
+    return {
+      largeImageId,
+      smallImageId,
+      largeImageExternalUrl,
+      smallImageExternalUrl,
+    };
+  };
+
+  const renderActivitiesSection = (): ReactNode[] => {
+    if (!activity.show || !activities || activities.length === 0) {
+      return [];
+    }
+
+    return activities.map((currentActivity) => {
+      const {
+        largeImageId,
+        smallImageId,
+        largeImageExternalUrl,
+        smallImageExternalUrl,
+      } = getImageUrls(currentActivity);
+
+      const largeImage = largeImageExternalUrl
+        ? `http://${largeImageExternalUrl}`
+        : currentActivity.assets?.large_image
+        ? `https://cdn.discordapp.com/app-assets/${currentActivity.application_id}/${largeImageId}.webp?size=80`
+        : undefined;
+
+      const smallImage = smallImageExternalUrl
+        ? `http://${smallImageExternalUrl}`
+        : currentActivity.assets?.small_image
+        ? `https://cdn.discordapp.com/app-assets/${currentActivity.application_id}/${smallImageId}.webp?size=80`
+        : undefined;
+
+      const party = currentActivity.party
+        ? {
+            // @ts-expect-error - TS doesn't know that size is an array
+            currentSize: currentActivity.party.size?.[0] ?? null,
+            // @ts-expect-error - TS doesn't know that size is an array
+            maxSize: currentActivity.party.size?.[1] ?? null,
+          }
+        : undefined;
+
+      const startTime =
+        currentActivity.timestamps?.start && activity.showElapsedTime
+          ? currentActivity.timestamps.start
+          : undefined;
+
+      const buttonText = currentActivity.buttons?.[0];
+
       return (
         <ActivitySection
+          key={currentActivity.id}
           title={activity.title}
           primaryColor={primaryColor}
-          largeImage={
-            largeImageExternalUrl
-              ? `http://${largeImageExternalUrl}`
-              : currentActivity.assets?.large_image
-              ? `https://cdn.discordapp.com/app-assets/${currentActivity.application_id}/${largeImageId}.webp?size=80`
-              : undefined
-          }
-          smallImage={
-            smallImageExternalUrl
-              ? `http://${smallImageExternalUrl}`
-              : currentActivity.assets?.small_image
-              ? `https://cdn.discordapp.com/app-assets/${currentActivity.application_id}/${smallImageId}.webp?size=80`
-              : undefined
-          }
+          largeImage={largeImage}
+          smallImage={smallImage}
           applicationId={currentActivity.application_id}
           name={currentActivity.name}
           state={currentActivity.state}
           details={currentActivity.details}
-          // Only render party if it's not null
-          {...(currentActivity.party && {
-            party: {
-              currentSize: currentActivity.party.size
-                ? // @ts-expect-error: Party could be null
-                  currentActivity.party.size[0]
-                : null,
-              maxSize: currentActivity.party.size
-                ? // @ts-expect-error: Party could be null
-                  currentActivity.party.size[1]
-                : null,
-            },
-          })}
-          // Only render elapsed time if not null and displayElapsedTime is true
+          party={party}
           elapsedText={activity.timeElapsedText}
           timeAlignment={activity.timeAlignment}
-          {...(currentActivity.timestamps?.start &&
-            activity.showElapsedTime && {
-              startTime: currentActivity.timestamps.start,
-            })}
-          // If present, pass the first button's text to the component
-          {...(currentActivity.buttons && {
-            buttonText: currentActivity.buttons[0],
-          })}
+          startTime={startTime}
+          buttonText={buttonText}
         />
       );
-    }
+    });
   };
 
   const renderSections = () => {
@@ -178,17 +205,17 @@ const LanyardDiscordCard = ({
       if (spotify.show && lanyardData && lanyardData.spotify) {
         return renderSpotifySection();
       }
-      return renderActivitySection();
+      return renderActivitiesSection();
     } else if (priority === "activity" || priority === "default") {
-      if (activity.show && currentActivity) {
-        return renderActivitySection();
+      if (activity.show && activities && activities.length > 0) {
+        return renderActivitiesSection();
       }
       return renderSpotifySection();
     } else {
       return (
         <>
           {renderSpotifySection()}
-          {renderActivitySection()}
+          {renderActivitiesSection()}
         </>
       );
     }
@@ -213,12 +240,12 @@ const LanyardDiscordCard = ({
           </>
         )}
         <div className="space-y-2">
-        {aboutMe && <AboutMeSection {...aboutMe} />}
-        {memberSince && <MemberSinceSection {...memberSince} />}
-        {renderSections()}
-        {roles && <RoleSection {...roles} />}
-        {note && <NoteSection {...note} />}
-        {message && <MessageSection {...message} />}
+          {aboutMe && <AboutMeSection {...aboutMe} />}
+          {memberSince && <MemberSinceSection {...memberSince} />}
+          {renderSections()}
+          {roles && <RoleSection {...roles} />}
+          {note && <NoteSection {...note} />}
+          {message && <MessageSection {...message} />}
         </div>
       </>
 


### PR DESCRIPTION
As requested by BossDaily, added support for multiple activities at the same time.
By default only one activity is displayed to avoid cluttering the card.

Control number of activities by passing the `maxActivities` prop with a desired number to `LanyardDiscordCard`

Closes #28 