### PR TITLE
feat: add `BaseDiscordCard` export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import DiscordCard from "./components/DiscordCard";
 import LanyardDiscordCard from "./components/LanyardDiscordCard";
+import BaseDiscordCard from "./components/BaseDiscordCard"
 import './App.css'
 
-export { DiscordCard, LanyardDiscordCard }
+export { DiscordCard, LanyardDiscordCard, BaseDiscordCard }


### PR DESCRIPTION
I believe developers should have the ability to have their own card with their own desired CSS properties. Here is a simple change that would allow that by modifying the export.